### PR TITLE
Streamline startup sequence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
-version: "3.8"
-
 services:
   rproxy:
+    container_name: rproxy
     image: nginx
     restart: always
     networks:
-      - site
+      site:
+        aliases:
+            - mail.kelseywilliams.co
     ports:
       - "80:80"
       - "443:443"
@@ -14,6 +15,14 @@ services:
       - ./prod.conf:/etc/nginx/nginx.conf
       - /etc/letsencrypt/live/kelseywilliams.co/privkey.pem:/certs/privkey.pem:ro
       - /etc/letsencrypt/live/kelseywilliams.co/fullchain.pem:/certs/fullchain.pem:ro
+
+    depends_on:
+        redis:
+            condition: service_healthy
+        home:
+            condition: service_healthy
+        mouse:
+            condition: service_healthy
 
 
 

--- a/prod.conf
+++ b/prod.conf
@@ -69,8 +69,8 @@ http {
             # Mouse application logs
             access_log /logs/mouse_access.log main;
             error_log /logs/mouse_error.log warn;
-            
-            proxy_pass http://mouse:3001/;
+                       
+            proxy_pass http://mouse:3001; 
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -118,7 +118,7 @@ http {
             # rewrite ^/contact/?$ /contact.html last;
             
             # Proxy everything to home service
-            proxy_pass http://home:3000;
+            proxy_pass http://home:3027;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- Removed config for mail server as mail is sent via API now
- Removed docker-compose version for compatibility with recent docker update
- Changed server start up sequence to "gateway last" and added depends_on cases; gateway will now not start up without upstream apps healthy
- Changed port of home service to 3027.  All ports in website will be migrated to > 3027 as WSL update changes available ports for development on windows and to sync dev and prod, port migration is necessary.