### PR TITLE
Changed certbot path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
+      - /root/home/certbot:/certbot
       - ./logs/:/logs/
       - ./prod.conf:/etc/nginx/nginx.conf
       - /etc/letsencrypt/live/kelseywilliams.co/privkey.pem:/certs/privkey.pem:ro

--- a/prod.conf
+++ b/prod.conf
@@ -33,12 +33,7 @@ http {
         error_log /logs/http_redirects_error.log warn;
 
         location ^~ /.well-known/acme-challenge/ {
-            set $upstream acme;
-            proxy_pass http://$upstream:80;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            root /certbot;
         }
         
         return 301 https://$host$request_uri;
@@ -56,12 +51,7 @@ http {
         error_log /logs/kelseywilliams_error.log warn;
 
         location ^~ /.well-known/acme-challenge/ {
-            set $upstream acme;
-            proxy_pass http://$upstream:80;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            root /certbot;
         }
 
         # Mouse application - must come first


### PR DESCRIPTION
- Renewal is now done by a script using webroot to pass challenges
- Location of certbot challenge is passed as volume to proxy
- Requests to /.well-known/ are passed to root
- Proxy has been tested with a dry run of certbot renewal script to ensure connectivity